### PR TITLE
Refactor: useTitle maching function in jsonifyResult

### DIFF
--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -4,6 +4,7 @@ const request = require("sync-request")
 const dayjs = require("dayjs")
 const getEnv = require("./environment")
 const TestRailApi = require("./testRailApi")
+const NewmanResultModifier = require("./newmanResultModifier")
 const Logger = require("./logger")
 const requiredOptions = ["domain", "username", "apikey", "projectId"]
 
@@ -37,31 +38,16 @@ class TestRailReporter {
 
   jsonifyResults(executions) {
     // Minor optimization: filter out test cases with no tests to report
-    const filteredExecutions = executions.filter((testExecution) => {
+    let filteredExecutions = executions.filter((testExecution) => {
       return testExecution.assertions && testExecution.assertions.length > 0
     })
 
-    // If we're matching by full title, transform the names to use C123 titles
-    //   so we don't have to modify follow up code
-    if (this.env.useTitles.toLowerCase() === "true") {
-      const testRailApi = this.testRailApi
-      const allCases = testRailApi.getCases()
-
-      filteredExecutions.forEach((execution) => {
-        execution.assertions.forEach((assertion) => {
-          const match = allCases.find(
-            (testCase) =>
-              testCase.title === assertion.assertion ||
-              testCase.title === execution.item.name ||
-              new RegExp(`^C${testCase.id}\\b`).test(execution.item.name),
-          )
-
-          if (match)
-            // eslint-disable-next-line no-param-reassign
-            assertion.assertion = `C${match.id} ${assertion.assertion}`
-        })
-      })
-    }
+    const resultModifier = new NewmanResultModifier(
+      this.env.useTitles,
+      this.testRailApi,
+      filteredExecutions,
+    )
+    filteredExecutions = resultModifier.addTestCaseIdsToAssertionsIfNeeded()
 
     const testCaseRegex = /\bC(\d+)\b/
     const duplicateFailingCases = []

--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -37,10 +37,8 @@ class TestRailReporter {
   }
 
   jsonifyResults(executions) {
-    // Minor optimization: filter out test cases with no tests to report
-    let filteredExecutions = executions.filter((testExecution) => {
-      return testExecution.assertions && testExecution.assertions.length > 0
-    })
+    let filteredExecutions =
+      this.getAssertionsIncludingAssertionsOnly(executions)
 
     const resultModifier = new NewmanResultModifier(
       this.env.useTitles,
@@ -238,6 +236,12 @@ class TestRailReporter {
     } else {
       console.error("\nnewman-reporter-testrail-neo: No test cases were found.")
     }
+  }
+
+  getAssertionsIncludingAssertionsOnly(executions) {
+    return executions.filter((testExecution) => {
+      return testExecution.assertions && testExecution.assertions.length > 0
+    })
   }
 }
 

--- a/lib/newmanResultModifier.js
+++ b/lib/newmanResultModifier.js
@@ -1,13 +1,13 @@
 class NewmanResultModifier {
   constructor(isUseTitle, testRailApi, orgExecutions) {
-    this.isUseTitle = isUseTitle;
-    this.testRailApi = testRailApi;
-    this.orgExecutions = orgExecutions;
+    this.isUseTitle = isUseTitle
+    this.testRailApi = testRailApi
+    this.orgExecutions = orgExecutions
   }
 
   addTestCaseIdsToAssertions() {
-    if (this.isUseTitle.toLowerCase() !== "true") return this.orgExecutions;
-    const allCases = this.testRailApi.getCases();
+    if (this.isUseTitle.toLowerCase() !== "true") return this.orgExecutions
+    const allCases = this.testRailApi.getCases()
 
     return this.orgExecutions.map((execution) => {
       const modifiedAssertions = execution.assertions.map((assertion) => {
@@ -15,17 +15,17 @@ class NewmanResultModifier {
           (testCase) =>
             testCase.title === assertion.assertion ||
             testCase.title === execution.item.name ||
-            new RegExp(`^C${testCase.id}\\b`).test(execution.item.name)
-        );
+            new RegExp(`^C${testCase.id}\\b`).test(execution.item.name),
+        )
 
         return match
           ? { ...assertion, assertion: `C${match.id} ${assertion.assertion}` }
-          : assertion;
-      });
+          : assertion
+      })
 
-      return { ...execution, assertions: modifiedAssertions };
-    });
+      return { ...execution, assertions: modifiedAssertions }
+    })
   }
 }
 
-module.exports = NewmanResultModifier;
+module.exports = NewmanResultModifier

--- a/lib/newmanResultModifier.js
+++ b/lib/newmanResultModifier.js
@@ -1,0 +1,31 @@
+class NewmanResultModifier {
+  constructor(isUseTitle, testRailApi, orgExecutions) {
+    this.isUseTitle = isUseTitle;
+    this.testRailApi = testRailApi;
+    this.orgExecutions = orgExecutions;
+  }
+
+  addTestCaseIdsToAssertions() {
+    if (this.isUseTitle.toLowerCase() !== "true") return this.orgExecutions;
+    const allCases = this.testRailApi.getCases();
+
+    return this.orgExecutions.map((execution) => {
+      const modifiedAssertions = execution.assertions.map((assertion) => {
+        const match = allCases.find(
+          (testCase) =>
+            testCase.title === assertion.assertion ||
+            testCase.title === execution.item.name ||
+            new RegExp(`^C${testCase.id}\\b`).test(execution.item.name)
+        );
+
+        return match
+          ? { ...assertion, assertion: `C${match.id} ${assertion.assertion}` }
+          : assertion;
+      });
+
+      return { ...execution, assertions: modifiedAssertions };
+    });
+  }
+}
+
+module.exports = NewmanResultModifier;

--- a/lib/newmanResultModifier.js
+++ b/lib/newmanResultModifier.js
@@ -5,7 +5,7 @@ class NewmanResultModifier {
     this.orgExecutions = orgExecutions
   }
 
-  addTestCaseIdsToAssertions() {
+  addTestCaseIdsToAssertionsIfNeeded() {
     if (this.isUseTitle.toLowerCase() !== "true") return this.orgExecutions
     const allCases = this.testRailApi.getCases()
 

--- a/test/TestrailReporter.spec.js
+++ b/test/TestrailReporter.spec.js
@@ -508,5 +508,52 @@ describe("TestrailReporter", () => {
         )
       })
     })
+
+    describe("getIncludingAssertionsExecutionsOnly", () => {
+      it("returns 1 executions when one has assertions and the other dose not have assertions", () => {
+        // arrange
+        setEnvVars(vi)
+        const sut = new TestrailReporter(makeSampleEmitter(vi.fn()), {}, {})
+        sut.env = getEnv()
+        const executions = makeNewmanResult({
+          assertionName: "case1",
+        })
+        const multiCaseExecutions = executions.concat(
+          makeNewmanResult({
+            assertionName: "case2",
+          }),
+        )
+        multiCaseExecutions[1].assertions = []
+
+        // act
+        const results =
+          sut.getAssertionsIncludingAssertionsOnly(multiCaseExecutions)
+
+        // assert
+        expect(results).toHaveLength(1)
+      })
+
+      it("returns 2 executions when both have assertions", () => {
+        // arrange
+        setEnvVars(vi)
+        const sut = new TestrailReporter(makeSampleEmitter(vi.fn()), {}, {})
+        sut.env = getEnv()
+        const executions = makeNewmanResult({
+          assertionName: "case1",
+        })
+        const multiCaseExecutions = executions.concat(
+          makeNewmanResult({
+            assertionName: "case2",
+          }),
+        )
+
+        // act
+        const results =
+          sut.getAssertionsIncludingAssertionsOnly(multiCaseExecutions)
+
+        // assert
+        expect(results).toHaveLength(2)
+      })
+    })
   })
 })

--- a/test/lib/newmanResultModifier.spec.js
+++ b/test/lib/newmanResultModifier.spec.js
@@ -31,7 +31,7 @@ describe("NewmanResultModifier", () => {
       const executions = makeNewmanResult()
       const sut = new NewmanResultModifier("false", fakeApi, executions)
       // act
-      const result = sut.addTestCaseIdsToAssertions()
+      const result = sut.addTestCaseIdsToAssertionsIfNeeded()
       // assert
       expect(result).toEqual(executions)
     })
@@ -50,7 +50,7 @@ describe("NewmanResultModifier", () => {
       const sut = new NewmanResultModifier("true", fakeApi, multiCaseExecutions)
 
       // act
-      const results = sut.addTestCaseIdsToAssertions()
+      const results = sut.addTestCaseIdsToAssertionsIfNeeded()
       // assert
       expect(results[0].assertions[0].assertion).toEqual("C1 case1")
       expect(results[1].assertions[0].assertion).toEqual("C2 case2")

--- a/test/lib/newmanResultModifier.spec.js
+++ b/test/lib/newmanResultModifier.spec.js
@@ -1,0 +1,57 @@
+import NewmanResultModifier from "../../lib/newmanResultModifier";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import makeNewmanResult from "../utils/newman";
+import { setEnvVars } from "../utils/env";
+import { makeFakeRequest, makeFakeTestRailApi } from "../utils/fake";
+
+const makeFakeApi = (vi, fakeResponse, env) => {
+  const defaultResponse = {
+    _links: {
+      next: null,
+    },
+    cases: [
+      { id: 1, title: "case1" },
+      { id: 2, title: "case2" },
+    ],
+  };
+  const fakeRequest = makeFakeRequest(vi, fakeResponse || defaultResponse);
+  return makeFakeTestRailApi(vi, fakeRequest, env);
+};
+
+describe("NewmanResultModifier", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetAllMocks();
+  });
+
+  describe("addTestCaseIdsToAssertions", () => {
+    it("nothing changes if isUseTitle is not true", () => {
+      // arrange
+      const fakeApi = makeFakeApi(vi, null, {});
+      const executions = makeNewmanResult();
+      const sut = new NewmanResultModifier("false", fakeApi, executions)
+      // act
+      const result = sut.addTestCaseIdsToAssertions();
+      // assert
+      expect(result).toEqual(executions);
+    });
+
+    it("addTestCaseIds to assertion titles", () => {
+        // arrange
+        const fakeApi = makeFakeApi(vi, null, {})
+        const executions = makeNewmanResult({
+            assertionName: "case1"
+        })
+        const multiCaseExecutions = executions.concat(makeNewmanResult({
+            assertionName: "case2"
+        }))
+        const sut = new NewmanResultModifier("true", fakeApi, multiCaseExecutions)
+
+        // act
+        const results = sut.addTestCaseIdsToAssertions()
+        // assert
+        expect(results[0].assertions[0].assertion).toEqual("C1 case1")
+        expect(results[1].assertions[0].assertion).toEqual("C2 case2")
+    })
+  });
+});

--- a/test/lib/newmanResultModifier.spec.js
+++ b/test/lib/newmanResultModifier.spec.js
@@ -1,8 +1,8 @@
-import NewmanResultModifier from "../../lib/newmanResultModifier";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import makeNewmanResult from "../utils/newman";
-import { setEnvVars } from "../utils/env";
-import { makeFakeRequest, makeFakeTestRailApi } from "../utils/fake";
+import { afterEach, describe, expect, it, vi } from "vitest"
+import NewmanResultModifier from "../../lib/newmanResultModifier"
+import { setEnvVars } from "../utils/env"
+import { makeFakeRequest, makeFakeTestRailApi } from "../utils/fake"
+import makeNewmanResult from "../utils/newman"
 
 const makeFakeApi = (vi, fakeResponse, env) => {
   const defaultResponse = {
@@ -13,45 +13,47 @@ const makeFakeApi = (vi, fakeResponse, env) => {
       { id: 1, title: "case1" },
       { id: 2, title: "case2" },
     ],
-  };
-  const fakeRequest = makeFakeRequest(vi, fakeResponse || defaultResponse);
-  return makeFakeTestRailApi(vi, fakeRequest, env);
-};
+  }
+  const fakeRequest = makeFakeRequest(vi, fakeResponse || defaultResponse)
+  return makeFakeTestRailApi(vi, fakeRequest, env)
+}
 
 describe("NewmanResultModifier", () => {
   afterEach(() => {
     vi.unstubAllEnvs()
-    vi.resetAllMocks();
-  });
+    vi.resetAllMocks()
+  })
 
   describe("addTestCaseIdsToAssertions", () => {
     it("nothing changes if isUseTitle is not true", () => {
       // arrange
-      const fakeApi = makeFakeApi(vi, null, {});
-      const executions = makeNewmanResult();
+      const fakeApi = makeFakeApi(vi, null, {})
+      const executions = makeNewmanResult()
       const sut = new NewmanResultModifier("false", fakeApi, executions)
       // act
-      const result = sut.addTestCaseIdsToAssertions();
+      const result = sut.addTestCaseIdsToAssertions()
       // assert
-      expect(result).toEqual(executions);
-    });
+      expect(result).toEqual(executions)
+    })
 
     it("addTestCaseIds to assertion titles", () => {
-        // arrange
-        const fakeApi = makeFakeApi(vi, null, {})
-        const executions = makeNewmanResult({
-            assertionName: "case1"
-        })
-        const multiCaseExecutions = executions.concat(makeNewmanResult({
-            assertionName: "case2"
-        }))
-        const sut = new NewmanResultModifier("true", fakeApi, multiCaseExecutions)
+      // arrange
+      const fakeApi = makeFakeApi(vi, null, {})
+      const executions = makeNewmanResult({
+        assertionName: "case1",
+      })
+      const multiCaseExecutions = executions.concat(
+        makeNewmanResult({
+          assertionName: "case2",
+        }),
+      )
+      const sut = new NewmanResultModifier("true", fakeApi, multiCaseExecutions)
 
-        // act
-        const results = sut.addTestCaseIdsToAssertions()
-        // assert
-        expect(results[0].assertions[0].assertion).toEqual("C1 case1")
-        expect(results[1].assertions[0].assertion).toEqual("C2 case2")
+      // act
+      const results = sut.addTestCaseIdsToAssertions()
+      // assert
+      expect(results[0].assertions[0].assertion).toEqual("C1 case1")
+      expect(results[1].assertions[0].assertion).toEqual("C2 case2")
     })
-  });
-});
+  })
+})

--- a/test/systemTest/useTitle.json
+++ b/test/systemTest/useTitle.json
@@ -1,0 +1,42 @@
+{
+  "info": {
+    "_postman_id": "hoge",
+    "name": "UseTestTitleTest",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "2"
+  },
+  "item": [
+    {
+      "name": "Get",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"MatchIfTestTitleEnvIsSettedWithoutCaseId1\", function () {",
+              "    pm.expect(pm.response.code).to.be.eq(200);",
+              "});",
+              "",
+              "pm.test(\"MatchIfTestTitleEnvIsSettedWithoutCaseId2\", function () {",
+              "    pm.expect(pm.response.code).to.be.eq(200);",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://github.com/bun913/newman-reporter-neo",
+          "protocol": "https",
+          "host": ["github", "com"],
+          "path": ["bun913", "newman-reporter-neo"]
+        }
+      },
+      "response": []
+    }
+  ]
+}


### PR DESCRIPTION
## Detail

I've done refactoring `jsonifyResult` function as follows:

- Refactor  the functions when `TESTRAIL_TITLE_MATCHING` environment is setted:
    - When `TESTRAIL_TITLE_MATCHING` is "true"
        - match assertions that includes newman execution results with test case titles on TestRail
    - Example
        - (Normal Behavior)
            - Newman assertion Name `C1 HogeTest` is matched with test case id1: `FugaTestCase`  on TestRail
        - (If TESTRAIL_TITLE_MATCHING is true)
            - Newman Assertion Name `HogeTest` is matched with test case id1: `HogeTest` on TestRail
                - User don't have to include test case id in assertion titles on newman executions
- I created a class which is named `NewmanResultModifier`
    - This classe is responsible for changing newman execution results if needed
- In the end, I reduce lines from `jsonifyResult` , divided responsibilities into classes with clearer behavior and improving testability

## Confirmed

- I've done system test on my TestRail
- Confirmed points are as follows:
    - [x] Check `TESTRAIL_TITLE_MATCHING` isn't setted (default false)
    - [x] Check `TESTRAIL_TITLE_MATCHING` is setted
        - User can match TestRail test case by using tittle name
        - Please refer to the ./test/systemTest/useTitle.json
